### PR TITLE
[EXE-1556] Add config to skip loading database functions 

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -432,6 +432,9 @@ public class HiveConf extends Configuration {
    * in the underlying Hadoop configuration.
    */
   public static enum ConfVars {
+    // AIQ stuff
+    LOAD_DATABASE_FUNCTIONS("hive.exec.aiq.load.database.functions", true,
+        "Load database functions on Hive startup."),
     // QL execution stuff
     SCRIPTWRAPPER("hive.exec.script.wrapper", null, ""),
     PLAN("hive.exec.plan", "", ""),

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -243,28 +243,31 @@ public class Hive {
 
 
   public void reloadFunctions() throws HiveException {
-    HashSet<String> registryFunctions = new HashSet<String>(
-        FunctionRegistry.getFunctionNames(".+\\..+"));
-    for (Function function : getAllFunctions()) {
-      String functionName = function.getFunctionName();
-      try {
-        LOG.info("Registering function " + functionName + " " + function.getClassName());
-        String qualFunc = FunctionUtils.qualifyFunctionName(functionName, function.getDbName());
-        FunctionRegistry.registerPermanentFunction(qualFunc, function.getClassName(), false,
-                    FunctionTask.toFunctionResource(function.getResourceUris()));
-        registryFunctions.remove(qualFunc);
-      } catch (Exception e) {
-        LOG.warn("Failed to register persistent function " +
-                functionName + ":" + function.getClassName() + ". Ignore and continue.");
+    Hive db = get();
+    if (db.conf.getBoolVar(HiveConf.ConfVars.LOAD_DATABASE_FUNCTIONS)) {
+      HashSet<String> registryFunctions = new HashSet<String>(
+              FunctionRegistry.getFunctionNames(".+\\..+"));
+      for (Function function : getAllFunctions()) {
+        String functionName = function.getFunctionName();
+        try {
+          LOG.info("Registering function " + functionName + " " + function.getClassName());
+          String qualFunc = FunctionUtils.qualifyFunctionName(functionName, function.getDbName());
+          FunctionRegistry.registerPermanentFunction(qualFunc, function.getClassName(), false,
+                  FunctionTask.toFunctionResource(function.getResourceUris()));
+          registryFunctions.remove(qualFunc);
+        } catch (Exception e) {
+          LOG.warn("Failed to register persistent function " +
+                  functionName + ":" + function.getClassName() + ". Ignore and continue.");
+        }
       }
-    }
-    // unregister functions from local system registry that are not in getAllFunctions()
-    for (String functionName : registryFunctions) {
-      try {
-        FunctionRegistry.unregisterPermanentFunction(functionName);
-      } catch (Exception e) {
-        LOG.warn("Failed to unregister persistent function " +
-            functionName + "on reload. Ignore and continue.");
+      // unregister functions from local system registry that are not in getAllFunctions()
+      for (String functionName : registryFunctions) {
+        try {
+          FunctionRegistry.unregisterPermanentFunction(functionName);
+        } catch (Exception e) {
+          LOG.warn("Failed to unregister persistent function " +
+                  functionName + "on reload. Ignore and continue.");
+        }
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -243,7 +243,7 @@ public class Hive {
 
 
   public void reloadFunctions() throws HiveException {
-    Hive db = get();
+    Hive db = get(false /*doRegisterAllFns*/);
     if (db.conf.getBoolVar(HiveConf.ConfVars.LOAD_DATABASE_FUNCTIONS)) {
       HashSet<String> registryFunctions = new HashSet<String>(
               FunctionRegistry.getFunctionNames(".+\\..+"));


### PR DESCRIPTION
Pickup https://github.com/ActionIQ/spark-hive/pull/3/files. This loading takes a long time and we dont directly call Hive functions, we call Spark functions which are implemented separately 

### Test Notes
```
mvn clean package -DskipTests
mvn test -pl ql
```

### Deploy Notes
```
mvn versions:set -DgenerateBackupPoms=false // bump version in another commit
mvn deploy -DskipTests -Pdist
```