### PR TITLE
[EXE-1556] Allow Hive to use external metastore clients like Glue

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -596,6 +596,9 @@ public class HiveConf extends Configuration {
     HADOOPNUMREDUCERS("mapreduce.job.reduces", -1, "", true),
 
     // Metastore stuff. Be sure to update HiveConf.metaVars when you add something here!
+    IMETASTORE_CLIENT_FACTORY_CLASS("hive.imetastoreclient.factory.class",
+                "org.apache.hadoop.hive.ql.metadata.SessionHiveMetaStoreClientFactory",
+                "The name of the factory class that produces objects implementing the IMetaStoreClient interface."),
     METASTOREWAREHOUSE("hive.metastore.warehouse.dir", "/user/hive/warehouse",
         "location of default database for the warehouse"),
     METASTOREURIS("hive.metastore.uris", "",

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -146,6 +146,7 @@ import org.apache.hadoop.hive.shims.ShimLoader;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hive.common.util.ReflectionUtil;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -171,6 +172,7 @@ public class Hive {
   static final private Logger LOG = LoggerFactory.getLogger("hive.ql.metadata.Hive");
 
   private HiveConf conf = null;
+  private String metaStoreClientFactoryClassName;
   private IMetaStoreClient metaStoreClient;
   private SynchronizedMetaStoreClient syncMetaStoreClient;
   private UserGroupInformation owner;
@@ -391,6 +393,7 @@ public class Hive {
    */
   private Hive(HiveConf c, boolean doRegisterAllFns) throws HiveException {
     conf = c;
+    metaStoreClientFactoryClassName = conf.getVar(HiveConf.ConfVars.IMETASTORE_CLIENT_FACTORY_CLASS);
     if (doRegisterAllFns) {
       registerAllFunctionsOnce();
     }
@@ -3567,8 +3570,7 @@ private void constructOneLBLocationMap(FileStatus fSta,
   }
 
   /**
-   * Creates a metastore client. Currently it creates only JDBC based client as
-   * File based store support is removed
+   * Creates a metastore client using a factory specified via HiveConf.
    *
    * @returns a Meta Store Client
    * @throws HiveMetaException
@@ -3576,37 +3578,41 @@ private void constructOneLBLocationMap(FileStatus fSta,
    */
   private IMetaStoreClient createMetaStoreClient(boolean allowEmbedded) throws MetaException {
 
+    HiveMetaStoreClientFactory factory;
+    try {
+      // IMetaStoreClient is not Configurable so pass "null" for Configuration
+      factory = (HiveMetaStoreClientFactory) ReflectionUtil.newInstance(
+          conf.getClassByName(metaStoreClientFactoryClassName), null);
+    } catch (Exception e) {
+      String errorMessage = "Unable to instantiate a metastore client factory "
+          + metaStoreClientFactoryClassName + ": " + e;
+      LOG.error(errorMessage, e);
+      throw new MetaException(errorMessage);
+    }
+
     HiveMetaHookLoader hookLoader = new HiveMetaHookLoader() {
-        @Override
-        public HiveMetaHook getHook(
-          org.apache.hadoop.hive.metastore.api.Table tbl)
+      @Override
+      public HiveMetaHook getHook(org.apache.hadoop.hive.metastore.api.Table tbl)
           throws MetaException {
 
-          try {
-            if (tbl == null) {
-              return null;
-            }
-            HiveStorageHandler storageHandler =
-              HiveUtils.getStorageHandler(conf,
-                tbl.getParameters().get(META_TABLE_STORAGE));
-            if (storageHandler == null) {
-              return null;
-            }
-            return storageHandler.getMetaHook();
-          } catch (HiveException ex) {
-            LOG.error(StringUtils.stringifyException(ex));
-            throw new MetaException(
-              "Failed to load storage handler:  " + ex.getMessage());
+        try {
+          if (tbl == null) {
+            return null;
           }
+          HiveStorageHandler storageHandler = HiveUtils.getStorageHandler(conf, tbl.getParameters()
+              .get(META_TABLE_STORAGE));
+          if (storageHandler == null) {
+            return null;
+          }
+          return storageHandler.getMetaHook();
+        } catch (HiveException ex) {
+          LOG.error(StringUtils.stringifyException(ex));
+          throw new MetaException("Failed to load storage handler:  " + ex.getMessage());
         }
-      };
+      }
+    };
 
-    if (conf.getBoolVar(ConfVars.METASTORE_FASTPATH)) {
-      return new SessionHiveMetaStoreClient(conf, hookLoader, allowEmbedded);
-    } else {
-      return RetryingMetaStoreClient.getProxy(conf, hookLoader, metaCallTimeMap,
-          SessionHiveMetaStoreClient.class.getName(), allowEmbedded);
-    }
+    return factory.createMetaStoreClient(conf, hookLoader, allowEmbedded, metaCallTimeMap);
   }
 
   public static class SchemaException extends MetaException {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMetaStoreClientFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMetaStoreClientFactory.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.metadata;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+/**
+ * Abstract factory that defines an interface for other factories that produce concrete
+ * MetaStoreClient objects.
+ * 
+ */
+public interface HiveMetaStoreClientFactory {
+
+  /**
+   * A method for producing IMetaStoreClient objects.
+   * 
+   * The implementation returned by this method must throw a MetaException if allowEmbedded = true
+   * and it does not support embedded mode.
+   * 
+   * @param conf
+   *          Hive Configuration.
+   * @param hookLoader
+   *          Hook for handling events related to tables.
+   * @param allowEmbedded
+   *          Flag indicating the implementation must run in-process, e.g. for unit testing or
+   *          "fast path".
+   * @param metaCallTimeMap
+   *          A container for storing entry and exit timestamps of IMetaStoreClient method
+   *          invocations.
+   * @return IMetaStoreClient An implementation of IMetaStoreClient.
+   * @throws MetaException
+   */
+  IMetaStoreClient createMetaStoreClient(HiveConf conf, HiveMetaHookLoader hookLoader,
+      boolean allowEmbedded, ConcurrentHashMap<String, Long> metaCallTimeMap) throws MetaException;
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClientFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClientFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.metadata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+/**
+ * Default MetaStoreClientFactory for Hive which produces SessionHiveMetaStoreClient objects.
+ * 
+ */
+public final class SessionHiveMetaStoreClientFactory implements HiveMetaStoreClientFactory {
+
+  @Override
+  public IMetaStoreClient createMetaStoreClient(final HiveConf conf, HiveMetaHookLoader hookLoader,
+      boolean allowEmbedded,
+      ConcurrentHashMap<String, Long> metaCallTimeMap) throws MetaException {
+
+    checkNotNull(conf, "conf cannot be null!");
+    checkNotNull(metaCallTimeMap, "metaCallTimeMap cannot be null!");
+
+    if (conf.getBoolVar(ConfVars.METASTORE_FASTPATH)) {
+      return new SessionHiveMetaStoreClient(conf, hookLoader, allowEmbedded);
+    } else {
+      return RetryingMetaStoreClient.getProxy(conf, hookLoader, metaCallTimeMap,
+          SessionHiveMetaStoreClient.class.getName(), allowEmbedded);
+    }
+  }
+
+}


### PR DESCRIPTION
Pickup https://issues.apache.org/jira/browse/HIVE-12679 which allows using AWS Glue as a hive metastore
 
### Test Plan
```
wget https://issues.apache.org/jira/secure/attachment/12958418/HIVE-12679.branch-2.3.patch /tmp/
patch -p0 < /tmp/HIVE-12679.branch-2.3.patch
mvn clean package -DskipTests
mvn test -pl common,ql
```

## Deploy Notes
```
mvn deploy -DskipTests -Pdist
```

[EXE-1556]: https://actioniq.atlassian.net/browse/EXE-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ