### PR TITLE
[EXE-1556] Rename hive glue config

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -599,7 +599,7 @@ public class HiveConf extends Configuration {
     HADOOPNUMREDUCERS("mapreduce.job.reduces", -1, "", true),
 
     // Metastore stuff. Be sure to update HiveConf.metaVars when you add something here!
-    IMETASTORE_CLIENT_FACTORY_CLASS("hive.imetastoreclient.factory.class",
+    IMETASTORE_CLIENT_FACTORY_CLASS("hive.metastore.client.factory.class",
                 "org.apache.hadoop.hive.ql.metadata.SessionHiveMetaStoreClientFactory",
                 "The name of the factory class that produces objects implementing the IMetaStoreClient interface."),
     METASTOREWAREHOUSE("hive.metastore.warehouse.dir", "/user/hive/warehouse",


### PR DESCRIPTION
Fix typo from https://github.com/ActionIQ/hive/pull/4, we want to keep the config key the same as it is in Spark 2